### PR TITLE
creado acControl.py sin cliente de mqtt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__/
 *.log
 rpi-cediquim-certs/
 *.json
+node_modules/
+yUp3qLUftKGGY01XdcL5/

--- a/acControl-watchdog.sh
+++ b/acControl-watchdog.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+ps -ef | grep /home/pi/aws_iot/acControl.py | grep -v grep
+if [ $? -eq 1 ]; then 
+   date
+   echo "Process not running, restarting acControl-mqtt-client.py"
+   python3 /home/pi/aws_iot/acControl.py -ri 10
+fi

--- a/acControl.json
+++ b/acControl.json
@@ -1,1 +1,1 @@
-{"minT":23,"maxT":27,"acStartHour":6,"acEndHour":18}
+{"minT":23,"maxT":27,"acStartHour":7,"acEndHour":19}

--- a/acControl.py
+++ b/acControl.py
@@ -1,0 +1,85 @@
+
+import json
+import time
+import argparse
+import os
+
+## Esta funcion devuelve la hora actual del sistema para determinar si el AC se activa o no
+def getHour():
+   from datetime import datetime
+   return int((((str(datetime.now())).split(' ')[1]).split('.')[0]).split(':')[0])
+
+
+## Read in command-line parameters
+parser = argparse.ArgumentParser()
+parser.add_argument("-min", "--min_temp", action="store", dest="minT", help="Min Temperature", required=False)
+parser.add_argument("-max", "--max_temp", action="store", dest="maxT", help="Max Temperature", required=False)
+parser.add_argument("-acStartHour", "--acStartHour", action="store", dest="acStartHour", help="acStartHour", required=False)
+parser.add_argument("-acEndHour", "--acEndHour", action="store", dest="acEndHour", help="acEndHour", required=False)
+parser.add_argument("-ri", "--refreshInterval", action="store", dest="refreshinterval", required=True, help="Refresh interval in Seconds")
+
+
+args = parser.parse_args()
+
+f = open("/home/pi/aws_iot/acControl.json","r")
+acControlJSON  = json.load(f)
+f.close()
+
+if args.minT != None:
+  minT = int(args.minT)
+else:
+  minT = acControlJSON["minT"]
+
+if args.maxT != None:
+  maxT = int(args.maxT)
+else:  
+  maxT = acControlJSON["maxT"]
+
+if args.acStartHour != None:
+  acStartHour = int(args.acStartHour)
+else:
+  acStartHour = acControlJSON["acStartHour"]
+
+if args.acEndHour != None:
+  acEndHour = int(args.acEndHour)
+else:  
+  acEndHour = acControlJSON["acEndHour"]
+
+  
+refreshinterval = args.refreshinterval
+
+
+
+while True:
+  ## Implementacion del control del AC
+  ## Cuando la temperatura sube >= 27.5, activa modo DRY de AC
+  currentHour = getHour()
+  ## Primero se revisa si el AC puede activarse con base en las horas de actividad del AC
+
+  
+  print("\n~~~~~~~~~~~ AC Control ~~~~~~~~~~~~~~")
+  print("acStartHour: "+repr(acStartHour))
+  print("acEndHour: "+repr(acEndHour))
+  print("currentHour: "+repr(currentHour))
+  print("minT: "+repr(minT))
+  print("maxT: "+repr(maxT))
+
+  ##Leer sht31dT 
+  try:
+    with open('/home/pi/aws_iot/sht31d.json','r') as f:
+      sht31d_json = json.load(f)
+      sht31dT = sht31d_json['t']
+      print("currentTemp: "+repr(sht31dT))
+      f.close()
+      if currentHour >= acStartHour and currentHour < acEndHour:
+         if sht31dT >= maxT: ##Max Temp
+            print("\n~~~~ AC Turned On! ~~~~\n")
+            os.system("/usr/bin/python3 /home/pi/aws_iot/rpi-i2c-cron.py 1") ##Activa modo auto del AC
+         if sht31dT <= minT: ##Min Temp
+            ## Cuando la temperatura <= 22 apaga el AC
+            print("\n~~~~ AC Turned Off! ~~~~\n")
+            os.system("/usr/bin/python3 /home/pi/aws_iot/rpi-i2c-cron.py 0") ##Apaga AC
+  except Exception as e:
+    print("**** acControl Exception: ",repr(e))
+  
+  time.sleep(int(refreshinterval))

--- a/aws-thing-shadow3.py
+++ b/aws-thing-shadow3.py
@@ -29,9 +29,6 @@ import json
 import argparse
 
 import os
-#import glob
-#import sys
-import paho.mqtt.client as mqtt 
 
 
 ## Se comento codigo referente a DHT22 porque falla mucho
@@ -50,15 +47,6 @@ GPIO.setwarnings(False)
 waterpumpPin = 22
 GPIO.setup(waterpumpPin, GPIO.OUT)
 GPIO.output(waterpumpPin,1) #1=apaga la bomba
-
-
-##Sensirion SHT31D
-#import board
-#import busio #https://circuitpython.readthedocs.io/en/latest/shared-bindings/busio/__init__.html#module-busio
-#import adafruit_sht31d
-#i2c = busio.I2C(board.SCL, board.SDA)
-#https://learn.adafruit.com/adafruit-sht31-d-temperature-and-humidity-sensor-breakout/python-circuitpython
-#sht31d = adafruit_sht31d.SHT31D(i2c)
 
 
 ##reedswitch
@@ -259,16 +247,6 @@ while not connected:
 
 
 
-#sps30Serial = '4FBFC0FBE824FFEA'
-#dht22H = 0.0
-#dht22T = 0.0
-
-## Esta funcion devuelve la hora actual del sistema para determinar si el AC se activa o no
-# def getHour():
-#    from datetime import datetime
-#    return int((((str(datetime.now())).split(' ')[1]).split('.')[0]).split(':')[0])
-
-
 ## sps30
 import sps30
 
@@ -329,24 +307,6 @@ while True:
         #Puede arrojar: AWSIoTPythonSDK.exception.AWSIoTExceptions.publishQueueDisabledException
         print("**** Error AWS IoT shadowUpdate: "+repr(e))
         continue
-
-
-    ## Implementacion del control del AC
-    ## Cuando la temperatura sube >= 27.5, activa modo DRY de AC
-    # currentHour = getHour()
-    # ## Primero se revisa si el AC puede activarse con base en las horas de actividad del AC
-    # print("acStartHour: "+repr(acStartHour))
-    # print("acEndHour: "+repr(acEndHour))
-    # print("currentHour: "+repr(currentHour))
-
-    # if currentHour >= acStartHour and currentHour <= acEndHour:
-    #    if sht31dT >= 27.0: ##Max Temp
-    #       print("\n~~~~ AC Turned On! ~~~~\n")
-    #       os.system("/usr/bin/python3 /home/pi/aws_iot/rpi-i2c-cron.py 1") ##Activa modo auto del AC
-    #    if sht31dT <= 23.5: ##Min Temp
-    #       ## Cuando la temperatura <= 22 apaga el AC
-    #       print("\n~~~~ AC Turned Off! ~~~~\n")
-    #       os.system("/usr/bin/python3 /home/pi/aws_iot/rpi-i2c-cron.py 0") ##Apaga AC
 
 
     time.sleep(int(refreshinterval))


### PR DESCRIPTION
creado la version acControl.py sin cliente de mqtt porque hay un error con el IOTStack y no se puede iniciar el broker MQTT